### PR TITLE
Fix # Return error for "HTTP/1.1 200 OK" responses

### DIFF
--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -52,6 +52,11 @@ function ShopifyConnect(params) {
       });
 
       res.on('end', function() {
+
+        if (!responseData && (res.statusCode >= 200 && res.statusCode < 300)){
+          return callback(null, null);
+        }
+
         var error = null;
         try {
           var j = JSON.parse(responseData);


### PR DESCRIPTION
Thank you very much for your Shopify integration module. 
Just met a trouble with HTTP/1.1 200 OK responses from Shopify. 
When I activate a recurring charge or delete it, Shopify retrieves an empty response and 'node-shopify' causes an error. It just trying to parse empty string as JSON.  There's my variant how to fix that. 